### PR TITLE
Add modeline to tailscale ACL file

### DIFF
--- a/tailscale-acls.json
+++ b/tailscale-acls.json
@@ -81,3 +81,4 @@
 	"nodeAttrs": [],
 }
 
+// vi: set ft=jsonc:


### PR DESCRIPTION
This prevents comments from being highlighted red in the GitHub web UI.